### PR TITLE
Add Fast DDS Python bindings [main][14086]

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -31,6 +31,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
     version: v1.1.0
+  fastdds_python:
+    type: git
+    url: https://github.com/eProsima/Fast-DDS-python.git
+    version: v1.0.1
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git


### PR DESCRIPTION
This PR adds Fast DDS-Python to `eprosima-dds-suite`. It cannot be merged until Fast DDS v2.6.0 is released and set in the dds-suite.repos file.