### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,15 +2,15 @@ repositories:
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v0.2.0
+    version: v0.3.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.23
+    version: v1.0.24
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.5.1
+    version: v2.6.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -18,15 +18,15 @@ repositories:
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.5.0
+    version: v0.6.0
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.1.1
+    version: v2.1.2
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.1.2
+    version: v1.2.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -34,4 +34,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.5.1
+    version: v2.6.0

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
     version: v1.1.0
+  fastdds_python:
+    type: git
+    url: https://github.com/eProsima/Fast-DDS-python.git
+    version: v1.0.1
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git


### PR DESCRIPTION
Update fastdds-suite dependencies:
* ddsrouter,v0.3.0;fastcdr,v1.0.24;fastdds,v2.6.0;fastdds_python,v1.0.1;fastdds_statistics_backend,v0.6.0;fastddsgen,v2.1.2;fastddsgen/thirdparty/idl-parser,v1.2.0;shapes-demo,v2.6.0