### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -10,27 +10,27 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.6.1
+    version: v2.7.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.1.0
+    version: v1.2.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.0.1
+    version: v1.1.0
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.6.0
+    version: v0.7.0
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.1.2
+    version: v2.1.3
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.2.0
+    version: v1.3.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -38,4 +38,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.6.0
+    version: v2.7.0


### PR DESCRIPTION
Update fastdds-suite dependencies:
* fastdds,v2.7.0;fastdds_monitor,v1.2.0;fastdds_python,v1.1.0;fastdds_statistics_backend,v0.7.0;fastddsgen,v2.1.3;fastddsgen/thirdparty/idl-parser,v1.3.0;shapes-demo,v2.7.0