### PR TITLE
Exclude external repositories when tracking dependencies

### DIFF
--- a/.github/workflows/track_dependencies.py
+++ b/.github/workflows/track_dependencies.py
@@ -91,6 +91,11 @@ if __name__ == '__main__':
         repo_name = url_elements[-1]
         repo_owner = url_elements[-2]
 
+        # Filter out repos not owned by us, as we should manage them more
+        # carefully
+        if repo_owner.lower() != 'eprosima':
+            continue
+
         tags = github_get_tags(
             repository_owner=repo_owner,
             repository_name=repo_name,


### PR DESCRIPTION
1. This was causing the dependency tracking in `main` to fail.
2. We cannot manage their release, so we should only upgrade manually.

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>