### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -6,11 +6,11 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.24
+    version: v1.0.25
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.7.1
+    version: v2.8.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -18,11 +18,11 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.1.0
+    version: v1.2.0
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.7.0
+    version: v0.7.1
   fastdds_visualizer_plugin:
     type: git
     url: https://github.com/eProsima/fastdds-visualizer-plugin.git
@@ -30,11 +30,11 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.1.3
+    version: v2.2.0
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.3.0
+    version: v1.4.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -46,4 +46,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.7.1
+    version: v2.8.0


### PR DESCRIPTION
Update fastdds-suite dependencies:
* fastcdr,v1.0.25;fastdds,v2.8.0;fastdds_python,v1.2.0;fastdds_statistics_backend,v0.7.1;fastddsgen,v2.2.0;fastddsgen/thirdparty/idl-parser,v1.4.0;shapes-demo,v2.8.0