### PR TITLE
Update xrcedds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,15 +2,15 @@ repositories:
   Micro-CDR:
     type: git
     url: https://github.com/eProsima/Micro-CDR.git
-    version: v2.0.0
+    version: v2.0.1
   Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: v2.2.1
+    version: v2.3.0
   Micro-XRCE-DDS-Client:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Client.git
-    version: v2.2.1
+    version: v2.3.0
   Micro-XRCE-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Gen
@@ -18,12 +18,12 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.25
+    version: v1.0.26
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.8.0
+    version: v2.9.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.1
+    version: v1.2.2


### PR DESCRIPTION
Update xrcedds-suite dependencies:
* Micro-CDR,v2.0.1;Micro-XRCE-DDS-Agent,v2.3.0;Micro-XRCE-DDS-Client,v2.3.0;fastcdr,v1.0.26;fastdds,v2.9.0;foonathan_memory_vendor,v1.2.2