### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,23 +2,23 @@ repositories:
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v1.0.0
+    version: v1.1.0
   dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v0.1.0
+    version: v0.2.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.25
+    version: v1.0.26
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.8.1
+    version: v2.9.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.2.1
+    version: v1.3.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
@@ -34,7 +34,7 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.2.0
+    version: v2.3.0
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
@@ -42,7 +42,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.1
+    version: v1.2.2
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -50,4 +50,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.8.1
+    version: v2.9.0


### PR DESCRIPTION
Update fastdds-suite dependencies:
* ddsrouter,v1.1.0;dev-utils,v0.2.0;fastcdr,v1.0.26;fastdds,v2.9.0;fastdds_monitor,v1.3.0;fastddsgen,v2.3.0;foonathan_memory_vendor,v1.2.2;shapes-demo,v2.9.0