### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -14,5 +14,13 @@
                 "-DQT_PATH=/opt/qt515",
             ],
         },
+
+        "controller_tool":
+        {
+            "cmake-args":
+            [
+                "-DBUILD_DDSRECORDER_CONTROLLER=ON",
+            ],
+        },
     }
 }

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -1,4 +1,12 @@
 repositories:
+  ddspipe:
+    type: git
+    url: https://github.com/eProsima/DDS-Pipe.git
+    version: v0.1.0
+  ddsrecorder:
+    type: git
+    url: https://github.com/eProsima/DDS-Recorder.git
+    version: v0.1.0
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
@@ -39,6 +47,10 @@ repositories:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
     version: v1.5.0
+  fastddsspy:
+    type: git
+    url: https://github.com/eProsima/Fast-DDS-spy.git
+    version: v0.1.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,31 +2,31 @@ repositories:
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v1.1.0
+    version: v1.2.0
   dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v0.2.0
+    version: v0.3.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.26
+    version: v1.0.27
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.9.1
+    version: v2.10.1
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.3.0
+    version: v1.4.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.0
+    version: v1.2.1
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.8.0
+    version: v0.10.0
   fastdds_visualizer_plugin:
     type: git
     url: https://github.com/eProsima/fastdds-visualizer-plugin.git
@@ -34,15 +34,15 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.3.0
+    version: v2.4.0
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.4.0
+    version: v1.5.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.2
+    version: v1.3.0
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -50,4 +50,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.9.1
+    version: v2.10.1


### PR DESCRIPTION
Update fastdds-suite dependencies:
* ddsrouter,v1.2.0;dev-utils,v0.3.0;fastcdr,v1.0.27;fastdds,v2.10.1;fastdds_monitor,v1.4.0;fastdds_python,v1.2.1;fastdds_statistics_backend,v0.10.0;fastddsgen,v2.4.0;fastddsgen/thirdparty/idl-parser,v1.5.0;foonathan_memory_vendor,v1.3.0;shapes-demo,v2.10.1