### PR TITLE
[17979] Forced int conversion to prevent string comparison

### DIFF
--- a/.github/workflows/track_dependencies.py
+++ b/.github/workflows/track_dependencies.py
@@ -123,15 +123,15 @@ if __name__ == '__main__':
                 args.branch in default_branches and
                 ver != tags[-1] and
                 (
-                    current_version[0] < new_version[0] or
+                    int(current_version[0]) < int(new_version[0]) or
                     (
-                        current_version[0] == new_version[0] and
-                        current_version[1] < new_version[1]
+                        int(current_version[0]) == int(new_version[0]) and
+                        int(current_version[1]) < int(new_version[1])
                     ) or
                     (
-                        current_version[0] == new_version[0] and
-                        current_version[1] == new_version[1] and
-                        current_version[2] < new_version[2]
+                        int(current_version[0]) == int(new_version[0]) and
+                        int(current_version[1]) == int(new_version[1]) and
+                        int(current_version[2]) < int(new_version[2])
                     )
                 )
             ) or
@@ -141,9 +141,9 @@ if __name__ == '__main__':
                 args.branch not in default_branches and
                 ver != tags[-1] and
                 (
-                    current_version[0] == new_version[0] and
-                    current_version[1] == new_version[1] and
-                    current_version[2] < new_version[2]
+                    int(current_version[0]) == int(new_version[0]) and
+                    int(current_version[1]) == int(new_version[1]) and
+                    int(current_version[2]) < int(new_version[2])
                 )
             )
         ):


### PR DESCRIPTION
Fast DDS version 2.10.0 was not being properly detected by the dependency tracking job since versions were being compared as strings instead of ints. This PR fixes that behavior.