### PR TITLE
Fixed matrix variable not being referenced properly

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -46,7 +46,7 @@ jobs:
           echo "updated=$(python3 .github/workflows/track_dependencies.py \
             --token ${{ secrets.RICHIPROSIMA_DDS_SUITE_TOKEN }} \
             --repos_file dds-suite.repos \
-            --branch matrix.tracked_branch \
+            --branch ${{ matrix.tracked_branch }} \
             --output_file dds-suite.repos)" >> $GITHUB_OUTPUT
 
       - name: Create pull request


### PR DESCRIPTION
Fixes a reference to matrix.tracked branch in the Github Actions configuration YAML not properly surrounded by matching `${{ }}` that caused the version comparison to be done against an unknown branch generating wrong Pull Requests. 

