### PR TITLE
Update eprosima-dds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -34,7 +34,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.27
+    version: v1.1.0
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -62,11 +62,11 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.4.0
+    version: v2.5.1
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.5.0
+    version: v1.6.0
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git
@@ -74,7 +74,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.0
+    version: v1.3.1
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Update eprosima-dds-suite dependencies:
* fastcdr,v1.1.0;fastddsgen,v2.5.1;fastddsgen/thirdparty/idl-parser,v1.6.0;foonathan_memory_vendor,v1.3.1