### PR TITLE
Update eprosima-dds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -38,7 +38,7 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.10.1
+    version: v2.11.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -46,7 +46,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.1
+    version: v1.2.2
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -82,4 +82,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.10.1
+    version: v2.11.0


### PR DESCRIPTION
Update eprosima-dds-suite dependencies:
* fastdds,v2.11.0;fastdds_python,v1.2.2;shapes-demo,v2.11.0