### PR TITLE
Update eprosima-dds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -66,7 +66,7 @@ repositories:
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.6.0
+    version: v1.7.0
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git


### PR DESCRIPTION
Update eprosima-dds-suite dependencies:
* fastddsgen/thirdparty/idl-parser,v1.7.0