### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,35 +2,35 @@ repositories:
   ddspipe:
     type: git
     url: https://github.com/eProsima/DDS-Pipe.git
-    version: v0.2.0
+    version: v0.3.0
   ddsrecordreplay:
     type: git
     url: https://github.com/eProsima/DDS-Record-Replay.git
-    version: v0.2.0
+    version: v0.3.0
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v2.0.0
+    version: v2.1.0
   dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v0.4.0
+    version: v0.5.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.1.1
+    version: v2.1.3
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.11.2
+    version: v2.13.2
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.5.0
+    version: v2.0.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.2
+    version: v1.4.0
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -38,7 +38,7 @@ repositories:
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.11.0
+    version: v1.0.0
   fastdds_visualizer_plugin:
     type: git
     url: https://github.com/eProsima/fastdds-visualizer-plugin.git
@@ -46,15 +46,15 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.5.1
+    version: v3.2.1
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.7.0
+    version: v3.0.0
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git
-    version: v0.2.0
+    version: v0.3.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.11.2
+    version: v2.13.1


### PR DESCRIPTION
Update fastdds-suite dependencies:
* ddspipe,v0.3.0;ddsrecordreplay,v0.3.0;ddsrouter,v2.1.0;dev-utils,v0.5.0;fastcdr,v2.1.3;fastdds,v2.13.2;fastdds_monitor,v2.0.0;fastdds_python,v1.4.0;fastdds_statistics_backend,v1.0.0;fastddsgen,v3.2.1;fastddsgen/thirdparty/idl-parser,v3.0.0;fastddsspy,v0.3.0;shapes-demo,v2.13.1