### PR TITLE
Update fastdds-suite-2.8.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -10,7 +10,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.25
+    version: v1.0.28
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -22,7 +22,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.0
+    version: v1.2.3
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
@@ -42,7 +42,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.1
+    version: v1.2.2
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Update fastdds-suite-2.8.x dependencies:
* fastcdr,v1.0.28;fastdds_python,v1.2.3;foonathan_memory_vendor,v1.2.2