### PR TITLE
Update fastdds-suite-2.11.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -22,7 +22,7 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.11.2
+    version: v2.11.3
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -30,7 +30,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.2
+    version: v1.2.3
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.11.2
+    version: v2.11.3


### PR DESCRIPTION
Update fastdds-suite-2.11.x dependencies:
* fastdds,v2.11.3;fastdds_python,v1.2.3;shapes-demo,v2.11.3