### PR TITLE
Update fastdds-suite-2.10.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -22,7 +22,7 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.10.3
+    version: v2.10.4
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -54,7 +54,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.0
+    version: v1.3.1
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -62,4 +62,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.10.3
+    version: v2.10.4


### PR DESCRIPTION
Update fastdds-suite-2.10.x dependencies:
* fastdds,v2.10.4;foonathan_memory_vendor,v1.3.1;shapes-demo,v2.10.4