### PR TITLE
[20536] Update create-pull-request action

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: eProsima/eProsima-CI/external/checkout@v0
       - id: list-branches
         run: echo "branches=$(python3 .github/workflows/list_branches.py --token ${{ secrets.RICHIPROSIMA_DDS_SUITE_TOKEN }})" >> $GITHUB_OUTPUT
 
@@ -26,7 +26,7 @@ jobs:
         tracked_branch: ${{ fromJson(needs.list-branches.outputs.branches) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           ref: ${{ matrix.tracked_branch }}
 
@@ -50,7 +50,7 @@ jobs:
             --output_file dds-suite.repos)" >> $GITHUB_OUTPUT
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.RICHIPROSIMA_DDS_SUITE_TOKEN }}
           committer: eProsima <ricardogonzalez@eprosima.com>


### PR DESCRIPTION
As observed [here](https://github.com/eProsima/DDS-Suite/actions/runs/8073016915/job/22055904620), there seems to be a bug on `create-pull-request` action when updating a PR. which was solved in the [v6.0.1 version](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1). This PR is upgrading to use the v6 version of that action; it also migrates the checkout steps to use eProsima-CI