### PR TITLE
Update fastdds-suite-2.12.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -22,7 +22,7 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.12.1
+    version: v2.12.2
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -30,7 +30,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.3.1
+    version: v1.3.2
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.12.1
+    version: v2.12.2


### PR DESCRIPTION
Update fastdds-suite-2.12.x dependencies:
* fastdds,v2.12.2;fastdds_python,v1.3.2;shapes-demo,v2.12.2