### PR TITLE
[20644] Correctly upgrade versions for default branches

### DIFF
--- a/.github/workflows/track_dependencies.py
+++ b/.github/workflows/track_dependencies.py
@@ -150,7 +150,14 @@ if __name__ == '__main__':
                         int(current_version[2]) < int(new_version[2])
                     )
                 )
-            ) or
+            )
+        ):
+            new_version_str = 'v' + '.'.join(new_version)
+            output += f'{repo},{new_version_str};'
+            repos_file['repositories'][repo]['version'] = new_version_str
+            updated = True
+
+        elif (
             # This is a new tag in the same minor SEMVER but with a higher
             # patch version on a non default branch; we want to update it
             (


### PR DESCRIPTION
This PR fixes the upgrading of the default branches allowing switching minors and even majors