### PR TITLE
Update fastdds-suite-2.11.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -46,11 +46,11 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.5.1
+    version: v2.5.2
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v1.6.0
+    version: v1.6.1
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git


### PR DESCRIPTION
Update fastdds-suite-2.11.x dependencies:
* fastddsgen,v2.5.2;fastddsgen/thirdparty/idl-parser,v1.6.1