### PR TITLE
Update fastdds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,7 +2,7 @@ repositories:
   ddspipe:
     type: git
     url: https://github.com/eProsima/DDS-Pipe.git
-    version: v0.4.0
+    version: v1.0.0
   ddsrecordreplay:
     type: git
     url: https://github.com/eProsima/DDS-Record-Replay.git
@@ -10,27 +10,27 @@ repositories:
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v2.2.0
+    version: v3.0.0
   dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v0.6.0
+    version: v1.0.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.2
+    version: v2.2.4
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.14.3
+    version: v3.0.1
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v2.1.0
+    version: v3.0.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.4.2
+    version: v2.0.0
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -38,23 +38,23 @@ repositories:
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v1.1.0
+    version: v2.0.0
   fastdds_visualizer_plugin:
     type: git
     url: https://github.com/eProsima/fastdds-visualizer-plugin.git
-    version: v1.0.0
+    version: v2.0.0
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v3.3.0
+    version: v4.0.1
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v3.0.0
+    version: v4.0.1
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git
-    version: v0.4.0
+    version: v1.0.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.14.3
+    version: v3.0.1


### PR DESCRIPTION
Update fastdds-suite dependencies:
* ddspipe,v1.0.0;ddsrouter,v3.0.0;dev-utils,v1.0.0;fastcdr,v2.2.4;fastdds,v3.0.1;fastdds_monitor,v3.0.0;fastdds_python,v2.0.0;fastdds_statistics_backend,v2.0.0;fastdds_visualizer_plugin,v2.0.0;fastddsgen,v4.0.1;fastddsgen/thirdparty/idl-parser,v4.0.1;fastddsspy,v1.0.0;shapes-demo,v3.0.1