### PR TITLE
Update fastdds-suite-3.0.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -50,7 +50,7 @@ repositories:
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v3.0.0
+    version: v3.0.1
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git


### PR DESCRIPTION
Update fastdds-suite-3.0.x dependencies:
* fastddsgen/thirdparty/idl-parser,v3.0.1