### PR TITLE
Update fastdds-suite-3.1.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -18,7 +18,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.4
+    version: v2.2.5
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -46,11 +46,11 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v4.0.1
+    version: v4.0.2
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v4.0.1
+    version: v4.0.2
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git


### PR DESCRIPTION
Update fastdds-suite-3.1.x dependencies:
* fastcdr,v2.2.5;fastddsgen,v4.0.2;fastddsgen/thirdparty/idl-parser,v4.0.2