### PR TITLE
Update .meta to fastdds and install examples

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -1,10 +1,11 @@
 
 {
     "names": {
-        "fastrtps": {
+        "fastdds": {
             "cmake-args": [
                 "-DSECURITY=ON",
                 "-DCOMPILE_EXAMPLES=ON",
+                "-DINSTALL_EXAMPLES=ON",
                 "-DFASTDDS_STATISTICS=ON",
             ],
         },


### PR DESCRIPTION
This PR updates the `colcon.meta` to `fastdds` and adds the `INSTALL_EXAMPLES` to it