### PR TITLE
Update fastdds-suite-3.1.x dependencies

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -5,7 +5,8 @@
             "cmake-args": [
                 "-DSECURITY=ON",
                 "-DCOMPILE_EXAMPLES=ON",
-                "-DFASTDDS_STATISTICS=ON",
+                "-DINSTALL_EXAMPLES=ON",
+                "-DFASTDDS_STATISTICS=ON"
             ],
         },
 

--- a/colcon.meta
+++ b/colcon.meta
@@ -1,7 +1,7 @@
 
 {
     "names": {
-        "fastrtps": {
+        "fastdds": {
             "cmake-args": [
                 "-DSECURITY=ON",
                 "-DCOMPILE_EXAMPLES=ON",

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -18,7 +18,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.4
+    version: v2.2.5
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -46,11 +46,11 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v4.0.1
+    version: v4.0.2
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v4.0.1
+    version: v4.0.2
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -30,7 +30,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v2.0.0
+    version: v2.1.0
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git

--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -22,7 +22,7 @@ repositories:
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.0.1
+    version: v3.1.0
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v3.0.1
+    version: v3.1.0


### PR DESCRIPTION
This PR updates the `.repos`, sets `colcon.meta` to fastdds and adds the `INSTALL_EXAMPLES` to it