### PR TITLE
Update fastdds-suite-3.4.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -18,11 +18,11 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.3.2
+    version: v2.3.4
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.4.0
+    version: v3.4.1
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -30,7 +30,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: 2.4.0
+    version: v2.4.1
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v3.4.0
+    version: v3.4.1


### PR DESCRIPTION
Update fastdds-suite-3.4.x dependencies:
* fastcdr,v2.3.4;fastdds,v3.4.1;fastdds_python,v2.4.1;shapes-demo,v3.4.1