### PR TITLE
Update fastdds-suite-2.6.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -6,11 +6,11 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.28
+    version: v1.0.29
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.6.10
+    version: v2.6.11
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -26,7 +26,7 @@ repositories:
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.1.3
+    version: v2.1.4
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
@@ -38,4 +38,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.6.10
+    version: v2.6.11


### PR DESCRIPTION
Update fastdds-suite-2.6.x dependencies:
* fastcdr,v1.0.29;fastdds,v2.6.11;fastddsgen,v2.1.4;shapes-demo,v2.6.11