### PR TITLE
Update fastdds-suite-2.10.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -18,7 +18,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.28
+    version: v1.0.29
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -54,7 +54,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.1
+    version: v1.3.2
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Update fastdds-suite-2.10.x dependencies:
* fastcdr,v1.0.29;foonathan_memory_vendor,v1.3.2