### PR TITLE
Update fastdds-suite-3.4.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -18,11 +18,11 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.3.4
+    version: v2.3.5
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.4.1
+    version: v3.4.2
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -58,7 +58,7 @@ repositories:
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.1
+    version: v1.3.2
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -66,4 +66,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v3.4.1
+    version: v3.4.2


### PR DESCRIPTION
Update fastdds-suite-3.4.x dependencies:
* fastcdr,v2.3.5;fastdds,v3.4.2;foonathan_memory_vendor,v1.3.2;shapes-demo,v3.4.2