### PR TITLE
Update eprosima-dds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,15 +2,15 @@ repositories:
   Micro-CDR:
     type: git
     url: https://github.com/eProsima/Micro-CDR.git
-    version: v2.0.1
+    version: v2.0.2
   Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: v2.4.3
+    version: v3.0.1
   Micro-XRCE-DDS-Client:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Client.git
-    version: v2.4.3
+    version: v3.0.1
   Micro-XRCE-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Gen
@@ -18,35 +18,35 @@ repositories:
   ddspipe:
     type: git
     url: https://github.com/eProsima/DDS-Pipe.git
-    version: v1.0.0
+    version: v1.4.0
   ddsrecordreplay:
     type: git
     url: https://github.com/eProsima/DDS-Record-Replay.git
-    version: v1.0.0
+    version: v1.4.0
   ddsrouter:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v3.0.0
+    version: v3.4.0
   dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v1.0.0
+    version: v1.4.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.4
+    version: v2.3.5
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.0.1
+    version: v3.4.2
   fastdds_monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v3.0.0
+    version: v4.0.0
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v2.0.0
+    version: v2.4.1
   fastdds_qos_profiles_manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -54,27 +54,27 @@ repositories:
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v2.0.0
+    version: v2.4.0
   fastdds_visualizer_plugin:
     type: git
     url: https://github.com/eProsima/fastdds-visualizer-plugin.git
-    version: v2.0.0
+    version: v2.3.0
   fastddsgen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v4.0.1
+    version: v4.2.0
   fastddsgen/thirdparty/idl-parser:
     type: git
     url: https://github.com/eProsima/IDL-Parser.git
-    version: v4.0.1
+    version: v4.2.0
   fastddsspy:
     type: git
     url: https://github.com/eProsima/Fast-DDS-spy.git
-    version: v1.0.0
+    version: v1.4.0
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.1
+    version: v1.4.0
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -82,4 +82,4 @@ repositories:
   shapes-demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v3.0.1
+    version: v3.4.2


### PR DESCRIPTION
Update eprosima-dds-suite dependencies:
* Micro-CDR,v2.0.2;Micro-XRCE-DDS-Agent,v3.0.1;Micro-XRCE-DDS-Client,v3.0.1;ddspipe,v1.4.0;ddsrecordreplay,v1.4.0;ddsrouter,v3.4.0;dev-utils,v1.4.0;fastcdr,v2.3.5;fastdds,v3.4.2;fastdds_monitor,v4.0.0;fastdds_python,v2.4.1;fastdds_statistics_backend,v2.4.0;fastdds_visualizer_plugin,v2.3.0;fastddsgen,v4.2.0;fastddsgen/thirdparty/idl-parser,v4.2.0;fastddsspy,v1.4.0;foonathan_memory_vendor,v1.4.0;shapes-demo,v3.4.2