### PR TITLE
Update xrcedds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -2,7 +2,7 @@ repositories:
   Micro-CDR:
     type: git
     url: https://github.com/eProsima/Micro-CDR.git
-    version: v2.0.1
+    version: v2.0.2
   Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
@@ -10,7 +10,7 @@ repositories:
   Micro-XRCE-DDS-Client:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Client.git
-    version: v3.0.0
+    version: v3.0.1
   Micro-XRCE-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Gen
@@ -18,12 +18,12 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v2.2.5
+    version: v2.3.5
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.1.0
+    version: v3.4.2
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.3.1
+    version: v1.4.0


### PR DESCRIPTION
Update xrcedds-suite dependencies:
* Micro-CDR,v2.0.2;Micro-XRCE-DDS-Client,v3.0.1;fastcdr,v2.3.5;fastdds,v3.4.2;foonathan_memory_vendor,v1.4.0